### PR TITLE
Add App safety setting page.

### DIFF
--- a/entry/src/main/ets/components/ItemDescription.ets
+++ b/entry/src/main/ets/components/ItemDescription.ets
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2021-2022 Huawei Device Co., Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@Component
+export struct ItemDescription {
+  private description: string  | Resource = '';
+
+  build() {
+    Text(this.description)
+      .fontSize($r('sys.float.ohos_id_text_size_body2'))
+      .fontColor($r('sys.color.ohos_id_color_text_secondary'))
+      .fontWeight(FontWeight.Regular)
+      .fontFamily('HarmonyHeiTi')
+      .lineHeight(19)
+      .width('100%')
+  }
+}

--- a/entry/src/main/ets/components/SubItemToggle.ets
+++ b/entry/src/main/ets/components/SubItemToggle.ets
@@ -16,9 +16,9 @@
 @Component
 export struct SubItemToggle {
   @LocalStorageProp('currentBreakpoint') curBp: string = 'sm';
+  onChange: (isOn: boolean) => void = () => {};
   private title: string | Resource = '';
   private isOn: boolean = false;
-
   build() {
     Row() {
       Text(this.title)
@@ -34,6 +34,9 @@ export struct SubItemToggle {
         .width(36)
         .height(20)
         .selectedColor('#007DFF')
+        .onChange((isOn: boolean) => {
+          this.onChange(isOn);
+        })
     }
     .height(48)
     .width('100%')

--- a/entry/src/main/ets/components/SubItemToggle.ets
+++ b/entry/src/main/ets/components/SubItemToggle.ets
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2021-2022 Huawei Device Co., Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@Component
+export struct SubItemToggle {
+  @LocalStorageProp('currentBreakpoint') curBp: string = 'sm';
+  private title: string | Resource = '';
+  private isOn: boolean = false;
+
+  build() {
+    Row() {
+      Text(this.title)
+        .fontSize($r('sys.float.ohos_id_text_size_body1'))
+        .fontColor($r('sys.color.ohos_id_color_text_primary'))
+        .fontWeight(FontWeight.Medium)
+        .textAlign(TextAlign.Start)
+
+      Blank()
+
+      Toggle({ type: ToggleType.Switch, isOn: this.isOn })
+        .id('ToggleSwitch')
+        .width(36)
+        .height(20)
+        .selectedColor('#007DFF')
+    }
+    .height(48)
+    .width('100%')
+    .padding({left: 8, right: 8})
+    .borderRadius(24)
+    .backgroundColor($r('app.color.itemInactivated'))
+  }
+}

--- a/entry/src/main/ets/entryability/EntryAbility.ets
+++ b/entry/src/main/ets/entryability/EntryAbility.ets
@@ -28,6 +28,9 @@ export default class EntryAbility extends UIAbility {
       }
 
       let windowClass: window.Window = windowStage.getMainWindowSync();
+      // 获取应用主窗口后存入AppStorage
+      AppStorage.setOrCreate("windowClass",windowClass);
+      AppStorage.setOrCreate("windowStage",windowStage);
 
       let isLayoutFullScreen = true;
       windowClass.setWindowLayoutFullScreen(isLayoutFullScreen)

--- a/entry/src/main/ets/pages/Index.ets
+++ b/entry/src/main/ets/pages/Index.ets
@@ -11,6 +11,8 @@ import { BusinessError } from '@kit.BasicServicesKit';
 import promptAction from '@ohos.promptAction'
 import { SteamConfigDialog } from '../utils/SteamConfigDialog';
 import { HOTPConfigDialog } from '../utils/HOTPConfigDialog';
+import { sendablePreferences } from '@kit.ArkData';
+import FaultLogger from '@ohos.faultLogger';
 
 let mmkv = MMKV.defaultMMKV();
 
@@ -20,6 +22,12 @@ struct Index {
   @Local appInfo: AppRuntimeInfo = AppStorageV2.connect(AppRuntimeInfo, () => new AppRuntimeInfo())!;
   @Local btn_token_add_clicked: number = 0;
   @Local arrConf: Array<TokenConfig> = [];
+
+  //安全性——隐私模式设置
+  private app_safety_privacy_enable:boolean =false;
+  //安全性应用锁定设置
+  private app_safety_lock_enable:boolean =false;
+
   private token_keys: string[] = []
   private dialog_totp_config?: CustomDialogController;
   private dialog_forti_config?: CustomDialogController;
@@ -29,6 +37,8 @@ struct Index {
     getContext(this).resourceManager.getStringSync($r('app.string.alert_remove_confirm_msg'))
 
   aboutToAppear(): void {
+    this.app_safety_privacy_enable = mmkv.decodeBool('app_safety_privacy_enable') ?? false;
+    this.app_safety_lock_enable = mmkv.decodeBool('app_safety_lock_enable') ?? false;
     this.token_keys = mmkv.decodeStringSet('token_keys') ?? []
     let token_str: string = JSON.stringify(new TokenConfig())
     this.token_keys.forEach(key => {
@@ -281,10 +291,20 @@ struct Index {
 
         TabContent() {
           SettingPage({
+            app_safety_privacy_enable:this.app_safety_privacy_enable,
+            app_safety_lock_enable:this.app_safety_lock_enable,
             arrConf: this.arrConf,
             backupReload: (conf) => {
               this.arrConf = conf;
               this.updateTokenConfigs(conf);
+            },
+            safetyPrivacyUpdateEvent:(IsOn)=>
+            {
+              mmkv.encodeBool('app_safety_privacy_enable',IsOn);
+            },
+            safetyLockUpdateEvent:(IsOn)=>
+            {
+              mmkv.encodeBool('app_safety_lock_enable',IsOn);
             }
           })
             .height('100%')

--- a/entry/src/main/ets/pages/Index.ets
+++ b/entry/src/main/ets/pages/Index.ets
@@ -1,3 +1,4 @@
+import { window } from '@kit.ArkUI';
 import { AppStorageV2 } from '@kit.ArkUI';
 import { AppRuntimeInfo, TokenConfig } from '../utils/CustomAppData';
 import { TOTPConfigDialog } from '../utils/TOTPConfigDialog';
@@ -23,6 +24,9 @@ struct Index {
   @Local btn_token_add_clicked: number = 0;
   @Local arrConf: Array<TokenConfig> = [];
 
+  private windowStage = AppStorage.get("windowStage") as window.WindowStage
+  private windowClass = AppStorage.get("windowClass") as window.Window
+
   //安全性——隐私模式设置
   private app_safety_privacy_enable:boolean =false;
   //安全性应用锁定设置
@@ -36,6 +40,11 @@ struct Index {
   private alert_dialog_str: string =
     getContext(this).resourceManager.getStringSync($r('app.string.alert_remove_confirm_msg'))
 
+  //页面显示事件 Todo 如果启用了锁定检查要验证pin
+  onPageShow(): void {
+
+  }
+  //build()函数之前执行 如果启用了隐私防截屏 在这里设置为隐私模式
   aboutToAppear(): void {
     this.app_safety_privacy_enable = mmkv.decodeBool('app_safety_privacy_enable') ?? false;
     this.app_safety_lock_enable = mmkv.decodeBool('app_safety_lock_enable') ?? false;
@@ -58,6 +67,23 @@ struct Index {
         })
       }
     })
+
+    //设置隐私模式
+    if (this.app_safety_privacy_enable) {
+      try {
+        this.windowClass.setWindowPrivacyMode(true, (err) => {
+          const errCode = err.code;
+          if (errCode) {
+            console.error('Failed to set the window to privacy mode. Cause:' + JSON.stringify(err));
+            return;
+          }
+          console.info('Succeeded in setting the window to privacy mode.');
+        });
+      } catch (exception) {
+        console.error('Failed to set the window to privacy mode. Cause:' + JSON.stringify(exception));
+      }
+    }
+
   }
 
   addTokenConfig(conf: TokenConfig): void {

--- a/entry/src/main/ets/pages/SettingPage.ets
+++ b/entry/src/main/ets/pages/SettingPage.ets
@@ -14,6 +14,49 @@ class backup_file {
   magic!: number;
   configs!: Array<TokenConfig>;
 }
+@CustomDialog
+@Component
+struct EncryptionPassWordDialog {
+  private textValue: string  = '';
+  private inputValue: string  = '';
+  controller?: CustomDialogController
+  cancel: () => void = () => {
+  }
+  confirm: (text:string) => void = (text:string) => {
+  }
+
+  build() {
+    Column() {
+      Text('Password').fontSize(20).margin({ top: 10, bottom: 10 })
+      TextInput({ placeholder: 'input your password...', text: this.textValue }).height(60).width('90%')
+        .type(InputType.Password)
+        .maxLength(32)
+        .showPasswordIcon(true)
+        .onChange((value: string) => {
+          this.textValue = value
+        })
+      Flex({ justifyContent: FlexAlign.SpaceAround }) {
+        Button($r('app.string.setting_backup_cancel'))
+          .onClick(() => {
+            if (this.controller != undefined) {
+              this.controller.close()
+              this.cancel()
+            }
+          }).backgroundColor(0xffffff).fontColor(Color.Black)
+        Button($r('app.string.setting_backup_confirm'))
+          .onClick(() => {
+            if (this.controller != undefined) {
+              this.inputValue = this.textValue
+              this.controller.close()
+              this.confirm(this.inputValue)
+            }
+          }).backgroundColor(0xffffff).fontColor(Color.Red)
+      }.margin({ bottom: 10 })
+
+
+    }.borderRadius(10)
+  }
+}
 
 @Preview
 @ComponentV2
@@ -27,15 +70,61 @@ export struct SettingPage {
   @Event safetyPrivacyUpdateEvent: (conf: boolean) => void = () => {};
   @Event safetyLockUpdateEvent: (conf: boolean) => void = () => {};
 
+  //备份时是否为导出模式
+  private backup_is_input:boolean = true;
   private backup_magic:number = 0x55aaeebb;
   private backup_save_uri: string = '';
   private backup_select_uri: string = '';
   private mediaFileUri: MediaFileUri = new MediaFileUri();
 
+  private dialogController: CustomDialogController | null = new CustomDialogController({
+    builder: EncryptionPassWordDialog({
+      cancel: ()=> {  },
+      confirm: (password:string)=> {
+        if (this.backup_is_input) {//如果是导出 就要调用导出加密函数
+          this.writeContentForSaveAsFileEncryption(this.backup_save_uri,password);
+        }
+        else
+        {
+          //加密导入
+          this.readContentFromSelectedFileEncryption(this.backup_save_uri,password);
+        }
+      },
+      textValue: "",
+      inputValue: ""
+    }),
+    cancel: () => {},
+    autoCancel: true,
+    onWillDismiss:(dismissDialogAction: DismissDialogAction)=> {
+      console.info("reason=" + JSON.stringify(dismissDialogAction.reason))
+      console.log("dialog onWillDismiss")
+      if (dismissDialogAction.reason == DismissReason.PRESS_BACK) {
+        dismissDialogAction.dismiss()
+      }
+      if (dismissDialogAction.reason == DismissReason.TOUCH_OUTSIDE) {
+        dismissDialogAction.dismiss()
+      }
+    },
+    alignment: DialogAlignment.Bottom,
+    offset: { dx: 0, dy: -20 },
+    gridCount: 4,
+    customStyle: false,
+    cornerRadius: 10,
+  })
+
+
   async writeContentForSaveAsFile(myUri: string): Promise<void> {
     let backup:backup_file = {magic: this.backup_magic, configs: this.arrConf};
     let backup_string = base32Encode(stringToIntArray(JSON.stringify(backup)));
     this.mediaFileUri.writeFileContent(myUri, backup_string);
+    promptAction.showToast({message: `BackUp Success.`})
+  }
+  //todo 实现加密导出
+  async writeContentForSaveAsFileEncryption(myUri: string,password:string): Promise<void> {
+    let backup:backup_file = {magic: this.backup_magic, configs: this.arrConf};
+    let backup_string = base32Encode(stringToIntArray(JSON.stringify(backup)));
+    this.mediaFileUri.writeFileContent(myUri, backup_string);
+    promptAction.showToast({message: `BackUp Success.`})
   }
 
   async readContentFromSelectedFile(myUri: string): Promise<void> {
@@ -52,39 +141,129 @@ export struct SettingPage {
     }
 
   }
+  //todo 实现加密导入
+  async readContentFromSelectedFileEncryption(myUri: string,password:string): Promise<void> {
+    let backup_string = this.mediaFileUri.readFileContent(myUri);
+    try {
+      let backup:backup_file = JSON.parse(intArrayToString(base32Decode(backup_string).buffer as ArrayBuffer));
+      if (backup.magic == this.backup_magic) {
+        this.backupReload(backup.configs);
+      } else {
+        promptAction.showToast({message: 'Error: invalid backup file!'})
+      }
+    } catch (err) {
+      promptAction.showToast({message: err.message})
+    }
+
+  }
 
   async callFilePickerSaveFile(): Promise<void> {
-    const documentSaveOptions = new picker.DocumentSaveOptions();
-    documentSaveOptions.newFileNames = [`totp_backup_${generateFileNameWithDate()}.json`];
-    documentSaveOptions.fileSuffixChoices = ['JSON|.json', '.json'];
-    let context = getContext(this) as common.Context;
-    const documentViewPicker = new picker.DocumentViewPicker(context);
-    documentViewPicker.save(documentSaveOptions).then((documentSaveResult: Array<string>) => {
-      if (documentSaveResult !== null && documentSaveResult !== undefined && documentSaveResult.length == 1) {
-        this.backup_save_uri = documentSaveResult[0];
-        Logger.info('documentViewPicker.save to file succeed and uris are:' + documentSaveResult);
-        this.writeContentForSaveAsFile(this.backup_save_uri);
+
+    this.getUIContext().showAlertDialog(
+      {
+        title: $r('app.string.setting_backup_output'),
+        subtitle: $r('app.string.setting_backup_output_des'),
+        message:$r('app.string.setting_backup_output_msg'),
+        autoCancel: true,
+        alignment: DialogAlignment.Bottom,
+        gridCount: 4,
+        offset: { dx: 0, dy: -20 },
+        buttonDirection: DialogButtonDirection.HORIZONTAL,
+        buttons: [
+          {
+            value: $r('app.string.setting_backup_type_default'),
+            action: () => {
+              const documentSaveOptions = new picker.DocumentSaveOptions();
+              documentSaveOptions.newFileNames = [`totp_backup_${generateFileNameWithDate()}.json`];
+              documentSaveOptions.fileSuffixChoices = ['JSON|.json', '.json'];
+              let context = getContext(this) as common.Context;
+              const documentViewPicker = new picker.DocumentViewPicker(context);
+              documentViewPicker.save(documentSaveOptions).then((documentSaveResult: Array<string>) => {
+                if (documentSaveResult !== null && documentSaveResult !== undefined && documentSaveResult.length == 1) {
+                  this.backup_save_uri = documentSaveResult[0];
+                  Logger.info('documentViewPicker.save to file succeed and uris are:' + documentSaveResult);
+                  this.writeContentForSaveAsFile(this.backup_save_uri);
+                }
+              }).catch((err: BusinessError) => {
+                Logger.error(`Invoke documentViewPicker.save failed, code is ${err.code}, message is ${err.message}`);
+              })
+            }
+          },
+          {
+            value: $r('app.string.setting_backup_type_enc'),
+            action: () => {
+              const documentSaveOptions = new picker.DocumentSaveOptions();
+              documentSaveOptions.newFileNames = [`totp_backup_${generateFileNameWithDate()}_.json`];
+              documentSaveOptions.fileSuffixChoices = ['BAK|.bak', '.bak'];
+              let context = getContext(this) as common.Context;
+              const documentViewPicker = new picker.DocumentViewPicker(context);
+              documentViewPicker.save(documentSaveOptions).then((documentSaveResult: Array<string>) => {
+                if (documentSaveResult !== null && documentSaveResult !== undefined && documentSaveResult.length == 1) {
+                  this.backup_save_uri = documentSaveResult[0];
+                  Logger.info('documentViewPicker.save to file succeed and uris are:' + documentSaveResult);
+                  this.dialogController?.open();
+                  //this.writeContentForSaveAsFileEncryption(this.backup_save_uri);
+                }
+              }).catch((err: BusinessError) => {
+                Logger.error(`Invoke documentViewPicker.save failed, code is ${err.code}, message is ${err.message}`);
+              })
+            }
+          },
+          {
+            value:$r('app.string.setting_backup_cancel'),
+            enabled: true,
+            defaultFocus: true,
+            style: DialogButtonStyle.HIGHLIGHT,
+            action: () => {
+              console.info('Callback when button3 is clicked')
+            }
+          },
+        ],
+        cancel: () => {
+          console.info('Closed callbacks')
+        },
+        onWillDismiss:(dismissDialogAction: DismissDialogAction)=> {
+          console.info("reason=" + JSON.stringify(dismissDialogAction.reason))
+          console.log("dialog onWillDismiss")
+          if (dismissDialogAction.reason == DismissReason.PRESS_BACK) {
+            dismissDialogAction.dismiss()
+          }
+          if (dismissDialogAction.reason == DismissReason.TOUCH_OUTSIDE) {
+            dismissDialogAction.dismiss()
+          }
+        }
       }
-    }).catch((err: BusinessError) => {
-      Logger.error(`Invoke documentViewPicker.save failed, code is ${err.code}, message is ${err.message}`);
-    })
+    );
+
   }
 
   async callFilePickerSelectFile(): Promise<void> {
     const documentSelectOptions = new picker.DocumentSelectOptions();
     documentSelectOptions.maxSelectNumber = 1;
-    documentSelectOptions.fileSuffixFilters = ['JSON|.json', '.json'];
+    documentSelectOptions.fileSuffixFilters = ['JSON|.json,BAK|.bak', '.json,.bak'];
     let context = getContext(this) as common.Context;
     const documentViewPicker = new picker.DocumentViewPicker(context);
     documentViewPicker.select(documentSelectOptions).then((documentSelectResult: Array<string>) => {
       if (documentSelectResult !== null && documentSelectResult !== undefined && documentSelectResult.length == 1) {
         this.backup_select_uri = documentSelectResult[0];
         Logger.info('documentViewPicker.select to file succeed and uris are:' + documentSelectResult);
-        this.readContentFromSelectedFile(this.backup_select_uri);
+        if (this.backup_select_uri.endsWith('.bak')) {
+          //后缀bak为加密包 唤醒加密导入弹窗
+          this.dialogController?.open();
+        }
+        else
+        {
+          this.readContentFromSelectedFile(this.backup_select_uri);
+        }
       }
     }).catch((err: BusinessError) => {
       Logger.error(`Invoke documentViewPicker.select failed, code is ${err.code}, message is ${err.message}`);
     })
+  }
+
+  // 在自定义组件即将析构销毁时将dialogController置空
+  aboutToDisappear() {
+    this.dialogController = null // 将dialogController置空
   }
 
   build() {
@@ -115,6 +294,7 @@ export struct SettingPage {
               .height(30)
               .backgroundColor($r('app.color.item_bg'))
               .onClick(() => {
+                this.backup_is_input=true;
                 this.callFilePickerSaveFile()
               })
               Divider().vertical(true)
@@ -132,6 +312,7 @@ export struct SettingPage {
               .height(30)
               .backgroundColor($r('app.color.item_bg'))
               .onClick(() => {
+                this.backup_is_input=false;
                 this.callFilePickerSelectFile()
               })
             }
@@ -164,17 +345,17 @@ export struct SettingPage {
                 left: 12,
                 right: 12
               })
-            SubItemToggle({title: $r('app.string.setting_safety_lock'),isOn:this.app_safety_lock_enable,
-              onChange:(IsOn:boolean)=>{
-                this.safetyLockUpdateEvent(IsOn);
-            }})
-            ItemDescription({description: $r('app.string.setting_safety_lock_des')})
-              .margin({
-                top: 0,
-                bottom: 2,
-                left: 12,
-                right: 12
-              })
+            // SubItemToggle({title: $r('app.string.setting_safety_lock'),isOn:this.app_safety_lock_enable,
+            //   onChange:(IsOn:boolean)=>{
+            //     this.safetyLockUpdateEvent(IsOn);
+            // }})
+            // ItemDescription({description: $r('app.string.setting_safety_lock_des')})
+            //   .margin({
+            //     top: 0,
+            //     bottom: 2,
+            //     left: 12,
+            //     right: 12
+            //   })
           }
           .alignItems(HorizontalAlign.Start)
         }

--- a/entry/src/main/ets/pages/SettingPage.ets
+++ b/entry/src/main/ets/pages/SettingPage.ets
@@ -6,7 +6,7 @@ import { base32Decode, base32Encode, stringToIntArray, intArrayToString, generat
 import promptAction from '@ohos.promptAction'
 import Logger from '../utils/Logger';
 import MediaFileUri from '../utils/MediaFileUri';
-
+import { MMKV } from '@tencent/mmkv';
 import { SubItemToggle } from '../components/SubItemToggle'
 import { ItemDescription } from '../components/ItemDescription'
 
@@ -18,8 +18,14 @@ class backup_file {
 @Preview
 @ComponentV2
 export struct SettingPage {
+  //安全性——隐私模式设置
+  @Param app_safety_privacy_enable:boolean =false;
+  //安全性应用锁定设置
+  @Param app_safety_lock_enable:boolean =false;
   @Require @Param arrConf: Array<TokenConfig> = [];
   @Event backupReload: (conf: Array<TokenConfig>) => void = () => {};
+  @Event safetyPrivacyUpdateEvent: (conf: boolean) => void = () => {};
+  @Event safetyLockUpdateEvent: (conf: boolean) => void = () => {};
 
   private backup_magic:number = 0x55aaeebb;
   private backup_save_uri: string = '';
@@ -140,15 +146,35 @@ export struct SettingPage {
         .padding(10)
       }
       .padding({ left: 10, right: 10})
+
       ListItem() {
         Row() {
           Column({ space: 5 }) {
-            Text($r('app.string.setting_about'))
+            Text($r('app.string.setting_safety'))
               .fontSize(20)
             Divider().vertical(false)
-            Text("Github: SoildFaker/ohtotptoken\nE-mail: enbinli@outlook.com")
-              .fontSize(10)
-              .fontColor($r('app.color.str_gray'))
+            SubItemToggle({title: $r('app.string.setting_safety_privacy'),isOn:this.app_safety_privacy_enable,
+              onChange:(IsOn:boolean)=>{
+                this.safetyPrivacyUpdateEvent(IsOn);
+              }})
+            ItemDescription({description: $r('app.string.setting_safety_privacy_des')})
+              .margin({
+                top: 0,
+                bottom: 2,
+                left: 12,
+                right: 12
+              })
+            SubItemToggle({title: $r('app.string.setting_safety_lock'),isOn:this.app_safety_lock_enable,
+              onChange:(IsOn:boolean)=>{
+                this.safetyLockUpdateEvent(IsOn);
+            }})
+            ItemDescription({description: $r('app.string.setting_safety_lock_des')})
+              .margin({
+                top: 0,
+                bottom: 2,
+                left: 12,
+                right: 12
+              })
           }
           .alignItems(HorizontalAlign.Start)
         }
@@ -158,28 +184,16 @@ export struct SettingPage {
         .padding(10)
       }
       .padding({ left: 10, right: 10})
+
       ListItem() {
         Row() {
           Column({ space: 5 }) {
-            Text($r('app.string.setting_safety'))
+            Text($r('app.string.setting_about'))
               .fontSize(20)
             Divider().vertical(false)
-            SubItemToggle({title: $r('app.string.setting_safety_privacy')})
-            ItemDescription({description: $r('app.string.setting_safety_privacy_des')})
-              .margin({
-                top: 8,
-                bottom: 24,
-                left: 12,
-                right: 12
-              })
-            SubItemToggle({title: $r('app.string.setting_safety_lock')})
-            ItemDescription({description: $r('app.string.setting_safety_lock_des')})
-              .margin({
-                top: 8,
-                bottom: 24,
-                left: 12,
-                right: 12
-              })
+            Text("Github: SoildFaker/ohtotptoken\nE-mail: enbinli@outlook.com")
+              .fontSize(10)
+              .fontColor($r('app.color.str_gray'))
           }
           .alignItems(HorizontalAlign.Start)
         }

--- a/entry/src/main/ets/pages/SettingPage.ets
+++ b/entry/src/main/ets/pages/SettingPage.ets
@@ -7,6 +7,9 @@ import promptAction from '@ohos.promptAction'
 import Logger from '../utils/Logger';
 import MediaFileUri from '../utils/MediaFileUri';
 
+import { SubItemToggle } from '../components/SubItemToggle'
+import { ItemDescription } from '../components/ItemDescription'
+
 class backup_file {
   magic!: number;
   configs!: Array<TokenConfig>;
@@ -65,7 +68,6 @@ export struct SettingPage {
     const documentSelectOptions = new picker.DocumentSelectOptions();
     documentSelectOptions.maxSelectNumber = 1;
     documentSelectOptions.fileSuffixFilters = ['JSON|.json', '.json'];
-    documentSelectOptions.defaultFilePathUri = 'file://docs/storage/Users/currentUser/Documents/totp_backup.json'
     let context = getContext(this) as common.Context;
     const documentViewPicker = new picker.DocumentViewPicker(context);
     documentViewPicker.select(documentSelectOptions).then((documentSelectResult: Array<string>) => {
@@ -138,7 +140,6 @@ export struct SettingPage {
         .padding(10)
       }
       .padding({ left: 10, right: 10})
-
       ListItem() {
         Row() {
           Column({ space: 5 }) {
@@ -148,6 +149,37 @@ export struct SettingPage {
             Text("Github: SoildFaker/ohtotptoken\nE-mail: enbinli@outlook.com")
               .fontSize(10)
               .fontColor($r('app.color.str_gray'))
+          }
+          .alignItems(HorizontalAlign.Start)
+        }
+        .backgroundColor($r('app.color.item_bg'))
+        .borderRadius(10)
+        .shadow({ radius: 10, color: $r('app.color.shadow'), offsetX: 10, offsetY: 10 })
+        .padding(10)
+      }
+      .padding({ left: 10, right: 10})
+      ListItem() {
+        Row() {
+          Column({ space: 5 }) {
+            Text($r('app.string.setting_safety'))
+              .fontSize(20)
+            Divider().vertical(false)
+            SubItemToggle({title: $r('app.string.setting_safety_privacy')})
+            ItemDescription({description: $r('app.string.setting_safety_privacy_des')})
+              .margin({
+                top: 8,
+                bottom: 24,
+                left: 12,
+                right: 12
+              })
+            SubItemToggle({title: $r('app.string.setting_safety_lock')})
+            ItemDescription({description: $r('app.string.setting_safety_lock_des')})
+              .margin({
+                top: 8,
+                bottom: 24,
+                left: 12,
+                right: 12
+              })
           }
           .alignItems(HorizontalAlign.Start)
         }

--- a/entry/src/main/ets/utils/FortiConfigDialog.ets
+++ b/entry/src/main/ets/utils/FortiConfigDialog.ets
@@ -64,18 +64,16 @@ export struct FortiConfigDialog {
     let symKeyBlob: cryptoFramework.DataBlob = { data: stringToIntArray(this.conf.FortiDevID) };
     let aesGenerator = cryptoFramework.createSymKeyGenerator('AES128');
     let aes_key = aesGenerator.convertKeySync(symKeyBlob);
-    aes_decoder.init(cryptoFramework.CryptoMode.DECRYPT_MODE, aes_key, aes_iv);
+    aes_decoder.initSync(cryptoFramework.CryptoMode.DECRYPT_MODE, aes_key, aes_iv);
     let base64 = new util.Base64Helper();
     try {
       let b64seed = base64.decodeSync(seed)
-      setTimeout(() => {
-        aes_decoder.doFinal({data: b64seed}).then((decryptData) => {
-          let decoder = new util.TextDecoder()
-          let decode_hex = decoder.decodeToString(decryptData.data.slice(0, 40))
-          this.conf.TokenKey = base32Encode(buffer.from(decode_hex, 'hex').buffer as Uint8Array)
-          this.btn_wait_from_forti = false;
-        });
-      }, 1000)
+      aes_decoder.doFinal({data: b64seed}).then((decryptData) => {
+        let decoder = new util.TextDecoder()
+        let decode_hex = decoder.decodeToString(decryptData.data.slice(0, 40))
+        this.conf.TokenKey = base32Encode(buffer.from(decode_hex, 'hex').buffer as Uint8Array)
+        this.btn_wait_from_forti = false;
+      });
     } catch (err) {
       this.btn_wait_from_forti = false;
       promptAction.showToast({message: `Error: ${err.message}`})

--- a/entry/src/main/module.json5
+++ b/entry/src/main/module.json5
@@ -12,6 +12,19 @@
     "requestPermissions": [
       {
         "name": "ohos.permission.INTERNET",
+      },
+      {
+        "name" : 'ohos.permission.PRIVACY_WINDOW'
+      },
+      {
+        "name": "ohos.permission.STORE_PERSISTENT_DATA",
+        "usedScene": {
+          "abilities": [
+            "EntryAbility"
+          ],
+          "when": "always"
+        },
+        "reason": "$string:app_name"
       }
     ],
     "deliveryWithInstall": true,

--- a/entry/src/main/resources/base/element/color.json
+++ b/entry/src/main/resources/base/element/color.json
@@ -18,7 +18,7 @@
     },
     {
       "name": "shadow",
-      "value": "#bbb"
+      "value": "#FFD9D9D9"
     },
     {
       "name": "str_gray",
@@ -35,6 +35,14 @@
     {
       "name": "tab_bar_bg",
       "value": "#fdfdfd"
+    },
+    {
+      "name": "itemActivated",
+      "value": "#335291FF"
+    },
+    {
+      "name": "itemInactivated",
+      "value": "#FFFFFF"
     }
   ]
 }

--- a/entry/src/main/resources/base/element/string.json
+++ b/entry/src/main/resources/base/element/string.json
@@ -139,6 +139,35 @@
     {
       "name": "setting_safety_lock_des",
       "value": "Require screen lock verification of your identity information when opening the application。"
+    },
+    {
+      "name": "setting_backup_output",
+      "value": "导出密码？"
+    },
+    {
+      "name": "setting_backup_output_des",
+      "value": "如果您选择普通导出方式，密码将以纯文本形式显示给有权访问该文件的任何人。是否确实要导出密码？"
+    },
+    {
+      "name": "setting_backup_output_msg",
+      "value": "请选择导出方式"
+    },
+    {
+      "name": "setting_backup_type_default",
+      "value": "默认"
+    },
+    {
+      "name": "setting_backup_type_enc",
+      "value": "加密"
+    }
+  ,
+    {
+      "name": "setting_backup_cancel",
+      "value": "取消"
+    },
+    {
+      "name": "setting_backup_confirm",
+      "value": "确认"
     }
   ]
 }

--- a/entry/src/main/resources/base/element/string.json
+++ b/entry/src/main/resources/base/element/string.json
@@ -107,6 +107,26 @@
     {
       "name": "setting_backup_import",
       "value": "Import"
+    },
+    {
+      "name": "setting_safety",
+      "value": "Safety"
+    },
+    {
+      "name": "setting_safety_privacy",
+      "value": "Privacy Mode"
+    },
+    {
+      "name": "setting_safety_privacy_des",
+      "value": "Prohibit other applications from capturing your screen, including one-time passwords. Please note that if you change this setting, please restart the application."
+    },
+    {
+      "name": "setting_safety_lock",
+      "value": "Application Lock"
+    },
+    {
+      "name": "setting_safety_lock_des",
+      "value": "Require screen lock verification of your identity information when opening the application。"
     }
   ]
 }

--- a/entry/src/main/resources/zh_CN/element/string.json
+++ b/entry/src/main/resources/zh_CN/element/string.json
@@ -139,6 +139,35 @@
     {
       "name": "setting_safety_lock_des",
       "value": "要求在打开应用时锁屏验证您的身份信息。"
+    },
+    {
+      "name": "setting_backup_output",
+      "value": "导出密码？"
+    },
+    {
+      "name": "setting_backup_output_des",
+      "value": "如果您选择普通导出方式，密码将以纯文本形式显示给有权访问该文件的任何人。是否确实要导出密码？"
+    },
+    {
+      "name": "setting_backup_output_msg",
+      "value": "请选择导出方式"
+    },
+    {
+      "name": "setting_backup_type_default",
+      "value": "明文"
+    },
+    {
+      "name": "setting_backup_type_enc",
+      "value": "加密"
+    }
+  ,
+    {
+      "name": "setting_backup_cancel",
+      "value": "取消"
+    },
+    {
+      "name": "setting_backup_confirm",
+      "value": "确认"
     }
   ]
 }

--- a/entry/src/main/resources/zh_CN/element/string.json
+++ b/entry/src/main/resources/zh_CN/element/string.json
@@ -107,6 +107,26 @@
     {
       "name": "setting_backup_import",
       "value": "导入"
+    },
+    {
+      "name": "setting_safety",
+      "value": "安全性"
+    },
+    {
+      "name": "setting_safety_privacy",
+      "value": "隐私模式"
+    },
+    {
+      "name": "setting_safety_privacy_des",
+      "value": "禁止其他应用程序捕获您的屏幕，包括一次性密码。请注意，如果更改此设置，请重启应用程序。"
+    },
+    {
+      "name": "setting_safety_lock",
+      "value": "应用锁定"
+    },
+    {
+      "name": "setting_safety_lock_des",
+      "value": "要求在打开应用时锁屏验证您的身份信息。"
     }
   ]
 }


### PR DESCRIPTION
您好我对您的项目非常感兴趣
我想参照Microsoft Authenticator新增一些实用性功能 目前工作已经完成
- [ 安全性]
   - [应用锁定]（废弃 目前华为尚未在next上实现应用锁）
   - [屏幕截图]


如下图
![image](https://github.com/user-attachments/assets/f303f357-ebd0-4a71-845f-ee08a8eb5de2)

隐私模式生效效果
![image](https://github.com/user-attachments/assets/ecf1b9c5-7a8b-486f-85b9-10ec27cf41ac)

另外我实现了

https://github.com/SoildFaker/ohtotptoken/issues/5

的加密导入导出UI
![image](https://github.com/user-attachments/assets/e5e8b7c8-1377-442e-97d0-592c91b0bd01)
![image](https://github.com/user-attachments/assets/c0707b27-d767-46f6-9058-d0b9c72be0e9)
并且根据导入时的文件后缀 .json 加密.bak 分别指向两个不同的加密解密/明文方法
您只需要在settingpage上实现
writeContentForSaveAsFileEncryption
readContentFromSelectedFileEncryption